### PR TITLE
Handle paths with spaces - thx OneDrive

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -x
 
 # Find the directory containing this script, so that executing the
 # script works as expected if the project directory isn't the CWD.
@@ -10,14 +10,14 @@ function echoerr() {
 }
 
 echo "Building project..."
-$SCRIPT_DIR/../gradlew compileJava compileTestJava
+"$SCRIPT_DIR/../gradlew" compileJava compileTestJava
 if [ $? -ne 0 ]; then
     echoerr "Compilation failed; not running tests"
     exit 1;
 fi
 
 echo "Running tests..."
-$SCRIPT_DIR/../gradlew test
+"$SCRIPT_DIR/../gradlew" test
 if [ $? -ne 0 ]; then
     echoerr "Tests failed; not creating artifact"
     exit 1;
@@ -25,4 +25,4 @@ fi
 
 # Drop jar to build/libs
 echo "Assembling release..."
-$SCRIPT_DIR/../gradlew assemble
+"$SCRIPT_DIR/../gradlew" assemble

--- a/bin/build
+++ b/bin/build
@@ -1,4 +1,4 @@
-#!/bin/bash -x
+#!/bin/bash
 
 # Find the directory containing this script, so that executing the
 # script works as expected if the project directory isn't the CWD.

--- a/bin/clean
+++ b/bin/clean
@@ -3,6 +3,6 @@ set -eu
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-$SCRIPT_DIR/../gradlew clean
+"$SCRIPT_DIR/../gradlew" clean
 
 

--- a/bin/run
+++ b/bin/run
@@ -9,4 +9,4 @@ if [ $? -ne 0 ]; then
    exit 1
 fi
 
-java -jar $SCRIPT_DIR/../build/libs/TicTacToe.jar
+java -jar "$SCRIPT_DIR/../build/libs/TicTacToe.jar"


### PR DESCRIPTION
# What?

Quoted commands using fullpath to handle spaces and special chars in path.
# Why?

Build scripts where failing in environments that had space in fullpath to project dir.
# Reviewer checklist

[ ] - The change introduces no untested code
[ ] - The change passes all existing tests
[ ] - The change introduces no typos or formatting errors
