### PR TITLE
Remove plumbing for variable sized boards

### DIFF
--- a/src/main/java/is/ru/tictactoe/Board.java
+++ b/src/main/java/is/ru/tictactoe/Board.java
@@ -1,12 +1,11 @@
 package is.ru.tictactoe;
 
 public class Board {
-    private final int boardSize;
+    private final int boardSize = 3;
     private int[][] board;
     
-    public Board(int boardSize) {
+    public Board() {
         this.board = new int[boardSize][boardSize];
-        this.boardSize = boardSize;
         for (int cellX = 0; cellX < boardSize; cellX++) {
             for (int cellY = 0; cellY < boardSize; cellY++) {
                 this.board[cellX][cellY] = -1;
@@ -17,11 +16,11 @@ public class Board {
     }
     
     public int boardSize() {
-        return boardSize;
+        return this.boardSize;
     }
     
     public int getCell(int cellX, int cellY) {
-        return board[cellX][cellY];
+        return this.board[cellX][cellY];
     }
 
     /* setCellOnce - Set (cellX, cellY) to value if-and-only-if it hasn't been set before.

--- a/src/main/java/is/ru/tictactoe/Engine.java
+++ b/src/main/java/is/ru/tictactoe/Engine.java
@@ -13,8 +13,8 @@ public class Engine {
         GAME_IN_PROGRESS,
     }
     
-    public Engine(int boardSize) {
-        this(new Board(boardSize));
+    public Engine() {
+        this(new Board());
     }
 
     public Engine(Board b) {

--- a/src/test/java/is/ru/tictactoe/BoardTest.java
+++ b/src/test/java/is/ru/tictactoe/BoardTest.java
@@ -7,14 +7,11 @@ import org.junit.Test;
 public class BoardTest {
     
     @Test public final void testBoardSize() {
-        Assert.assertEquals(1, (new Board(1)).boardSize());
-        Assert.assertEquals(3, (new Board(3)).boardSize());
-        Assert.assertEquals(5, (new Board(5)).boardSize());
-        Assert.assertEquals(13, (new Board(13)).boardSize());
+        Assert.assertEquals(3, (new Board()).boardSize());
     }
 
     @Test public final void testThatBoardIsInitiallyEmpty() {
-        Board b = new Board(3);
+        Board b = new Board();
         
         for(int y = 0; y < b.boardSize(); y++) {
             for(int x = 0; x < b.boardSize(); x++) {
@@ -27,7 +24,7 @@ public class BoardTest {
     // case where a cell is set more than once
     @Test
     public final void testSetCellOnceThrows() {
-        Board b = new Board(3);
+        Board b = new Board();
         b.setCellOnce(0, 0, 1);
         try {
             b.setCellOnce(0, 0, 1);
@@ -40,7 +37,7 @@ public class BoardTest {
     // with getCell.
     @Test
     public final void testSetCellOnce() {
-        Board b = new Board(3);
+        Board b = new Board();
 
         b.setCellOnce(0, 0, 1);
         assertEquals(1, b.getCell(0, 0));

--- a/src/test/java/is/ru/tictactoe/EngineTest.java
+++ b/src/test/java/is/ru/tictactoe/EngineTest.java
@@ -6,7 +6,7 @@ import org.junit.Test;
 
 public class EngineTest {
 
-    private Engine engine = new Engine(3);
+    private Engine engine = new Engine();
 
     @Test
     public final void testMakeMove() throws IllegalMoveException {
@@ -75,35 +75,35 @@ public class EngineTest {
 
     @Test
     public final void testWinner() throws IllegalMoveException {
-        Engine e = new Engine(3);
+        Engine e = new Engine();
         System.out.println("Inside Winner()");
         assertEquals(Engine.GameResult.GAME_IN_PROGRESS, e.winner());
         
-        e = new Engine(3);
+        e = new Engine();
         e.makeMove(0, 0, 1);
         e.makeMove(1, 0, 1);
         e.makeMove(2, 0, 1);
         assertEquals(Engine.GameResult.PLAYER_1, e.winner());
         
-        e = new Engine(3);
+        e = new Engine();
         e.makeMove(0, 0, 2);
         e.makeMove(0, 1, 2);
         e.makeMove(0, 2, 2);
         assertEquals(Engine.GameResult.PLAYER_2, e.winner());
 
-        e = new Engine(3);
+        e = new Engine();
         e.makeMove(0, 2, 2);
         e.makeMove(1, 1, 2);
         e.makeMove(2, 0, 2);
         assertEquals(Engine.GameResult.PLAYER_2, e.winner());
         
-        e = new Engine(3);
+        e = new Engine();
         e.makeMove(2, 0, 1);
         e.makeMove(1, 1, 1);
         e.makeMove(0, 2, 1);
         assertEquals(Engine.GameResult.PLAYER_1, e.winner());
 
-        e = new Engine(3);
+        e = new Engine();
         e.makeMove(0, 0, 1);
         e.makeMove(0, 1, 1);
         e.makeMove(0, 2, 2);


### PR DESCRIPTION
# What?

Stop supporting variable sized boards in board + engine constructors
# Why?

The rest of the game doesn't support anything but 3x3.  We can implement this again if and when we do that.
# Reviewer checklist

[ ] - The change introduces no untested code
[ ] - The change passes all existing tests
[ ] - The change introduces no typos or formatting errors
